### PR TITLE
feat(TaxonomyTermExtension): Pulled out code necessary to create tag fields ba-sis style

### DIFF
--- a/code/extensions/SiteTreeTaxonomyExtension.php
+++ b/code/extensions/SiteTreeTaxonomyExtension.php
@@ -7,36 +7,6 @@ class SiteTreeTaxonomyExtension extends DataExtension {
 	);
 
 	public function updateCMSFields(FieldList $fields) {
-
-		$taxonomySourceFunction = function(){
-
-			$source = TaxonomyTerm::get()->exclude('ParentID', 0);
-			$result = array();
-			if($source->count()){
-				foreach ($source as $term) {
-					$result[$term->ID] = $term->getTaxonomyName() . ": $term->Title";
-				}
-			}
-			asort($result);
-			return $result;
-		};
-
-		$taxonomySource = $taxonomySourceFunction();
-
-		$fields->addFieldToTab(
-			'Root.Main',
-			ListBoxField::create('Terms', 'Terms', $taxonomySource, null, null, true)
-				->useAddNew(
-					'TaxonomyTerm',
-					$taxonomySourceFunction,
-					FieldList::create(
-						TextField::create('Name', 'Title'),
-						DropdownField::create('ParentID', 'Parent', TaxonomyTerm::get()->filter('ParentID', 0)->map()->toArray())
-							->setEmptyString('')
-					)
-				),
-			'Content'
-		);
+		$fields->addFieldToTab('Root.Main', TaxonomyTermExtension::create_field('Terms', 'Terms'), 'Content');
 	}
-
 }

--- a/code/extensions/TaxonomyTermExtension.php
+++ b/code/extensions/TaxonomyTermExtension.php
@@ -7,4 +7,109 @@ class TaxonomyTermExtension extends DataExtension {
 		'Pages' => 'SiteTree'
 	);
 
+    public function updateCMSFields(FieldList $fields) {
+        if ($this->owner->CanBeTagged)
+        {
+            $field = $this->owner->createReverseTagField('Pages');
+            if ($field)
+            {
+                $fields->removeByName($field->getName());
+                $fields->addFieldToTab('Root.Main', $field);
+            }
+        }
+    }
+
+    /**
+     * Setup the appropriate field to manage tagging for a belongs_many_many
+     * relationship.
+     */
+    public function createReverseTagField($name) {
+        $belongs_many_many = $this->owner->config()->belongs_many_many;
+        if (!isset($belongs_many_many[$name]))
+        {
+            return null;
+        }
+        $className = $belongs_many_many[$name];
+        $s = singleton(($className === 'SiteTree') ? 'Page' : $className);
+        $visibleName = $s->plural_name();
+        $field = null;
+        if ($className::has_extension('Hierarchy'))
+        {
+            $field = TreeMultiselectField::create($name, 'Tagged '.$visibleName, $className);
+        }
+        else
+        {
+            $records = array();
+            foreach ($className::get() as $record)
+            {
+                if ($record->canView())
+                {
+                    $records[] = $record;
+                }
+            }
+            $field = ListboxField::create($name, 'Tagged '.$visibleName, $className::get()->map()->toArray())->setMultiple(true);
+        }
+        if ($field)
+        {
+            $field->setRightTitle($visibleName.' ('.$className.') using this tag');
+        }
+        return $field;
+    }
+	
+	/** 
+     * Set title to show in a default TreeDropdownField.
+     *
+     * @return string
+     */
+    public function getTreeTitle() {
+        return $this->owner->Name;
+    }
+
+    /**
+     * Default behaviour of ba-sis to only allow tagging
+     * of taxonomies with parents. See 'get_source'.
+     *
+     * @return boolean
+     */
+    public function getCanBeTagged() {
+        return ($this->owner->ParentID != 0);
+    }
+
+	/**
+     * Get field to add/remove taxonomies applied to the data object and
+     * sets up 'quickaddnew'
+     *
+     * @return ListboxField
+     */
+    public static function create_field($name, $title = null) {
+        // Get taxonomies to select
+        $sourceCallback = array(__CLASS__, 'get_source');
+        $result = ListboxField::create($name, $title, $sourceCallback(), null, null, true);
+        $result->useAddNew(
+                'TaxonomyTerm', 
+                $sourceCallback, 
+                FieldList::create(
+                    TextField::create('Name', 'Title'),
+                    DropdownField::create('ParentID', 'Parent', TaxonomyTerm::get()->filter('ParentID', 0)->map()->toArray())->setEmptyString('')
+                )
+        );
+        return $result;
+    }
+
+    /**
+     * Get the map of taxonomies for dropdown fields / etc
+     * NOTE: In its own function as 'useAddNew' requires the source be a callback function.
+     *
+     * @return ListboxField
+     */
+    public static function get_source() {
+        // Get taxonomies to select
+        $source = array();
+        foreach (TaxonomyTerm::get()->exclude('ParentID', 0) as $term) 
+        {
+            $source[$term->ID] = $term->getTaxonomyName() . ': '.$term->Title;
+        }
+        asort($source);
+        return $source;
+    }
 }


### PR DESCRIPTION
Pulled out code necessary to create tag fields ba-sis style so that I could easily reuse it for personal FileTaxonomyExtension, Also added functionality that allows for easy-to-use and configure reverse tagging, ie. adding pages to the tag.

Example of File extension code used in current project:

```
class FileTaxonomyTermExtension extends DataExtension {
    private static $belongs_many_many = array(
        'Files' => 'File'
    );

    public function updateCMSFields(FieldList $fields) {
        if ($this->owner->CanBeTagged)
        {
            $field = $this->owner->createReverseTagField('Files');
            if ($field)
            {
                $fields->removeByName($field->getName());
                $fields->addFieldToTab('Root.Main', $field);
            }
        }
    }
}
```

```
<?php

class FileTaxonomyExtension extends DataExtension {

    private static $many_many = array(
        'Terms' => 'TaxonomyTerm',
    );

    public function updateCMSFields(FieldList $fields) {
        $fields->addFieldToTab('Root.Main', TaxonomyTermExtension::create_field('Terms', 'Terms'));
    }
}
```
