### PR TITLE
feat(TaxonomyTerm): Remove 'Pages' gridfield, scaffolding is making i…

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -64,7 +64,7 @@ Link:
     - LinkExtension
 TaxonomyTerm:
   extensions:
-   - TaxonomyTermExtension
+   - BasisTaxonomyTermExtension
 PaginatedList:
   extensions:
     - PaginatedListIterationExtension

--- a/code/extensions/BasisTaxonomyTermExtension.php
+++ b/code/extensions/BasisTaxonomyTermExtension.php
@@ -1,5 +1,5 @@
 <?php
-class TaxonomyTermExtension extends DataExtension {
+class BasisTaxonomyTermExtension extends DataExtension {
 
 	private static $api_access = true;
 
@@ -8,6 +8,8 @@ class TaxonomyTermExtension extends DataExtension {
 	);
 
     public function updateCMSFields(FieldList $fields) {
+        $childrenField = $fields->dataFieldByName('Children');
+        $fields->removeByName(array('Pages', 'Children'));
         if ($this->owner->CanBeTagged)
         {
             $field = $this->owner->createReverseTagField('Pages');
@@ -16,6 +18,10 @@ class TaxonomyTermExtension extends DataExtension {
                 $fields->removeByName($field->getName());
                 $fields->addFieldToTab('Root.Main', $field);
             }
+        }
+        // Move $Children to end of main tab.
+        if ($childrenField) {
+            $fields->addFieldToTab('Root.Main', $childrenField);
         }
     }
 


### PR DESCRIPTION
- Remove 'Pages' gridfield, scaffolding is making it available when it shouldn't be
- Make extension move 'Children' gridfield to 'Root.Main' (less clicks, immediate clear that taxonomy terms have children to new users)
- Rename 'TaxonomyTermExtension' to 'BasisTaxonomyTermExtension' as the first name you go to choose when extending TaxonomyTerm is TaxonomyTermExtension (so this frees that name up)

![taxonomy_view](https://cloud.githubusercontent.com/assets/3859574/18660588/a6a65a56-7f54-11e6-8e9d-fa009f5deec3.png)
