### PR TITLE
fix(CustomMenuBlock): If not using Shea's Block module...

### DIFF
--- a/code/dataobjects/CustomMenuBlock.php
+++ b/code/dataobjects/CustomMenuBlock.php
@@ -1,4 +1,9 @@
 <?php
+
+if (!class_exists('Block')) {
+	return;
+}
+
 /**
  * A block that allows end users to manually build a custom (flat or nested) menu  
  * @author Shea Dawson <shea@silverstripe.com.au>


### PR DESCRIPTION
fix(CustomMenuBlock): If not using Shea's Block module and you want to iterate over classes/get configs in an abstract way, you'll cause SS to load this class and throw an error.
