### PR TITLE
fix(composer) Updated multisites version to symbiote vendor namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 		"symbiote/silverstripe-gridfieldextensions": "~1.0",
 		"symbiote/silverstripe-grouped-cms-menu": "~2.1",
 		"symbiote/silverstripe-metadata": "~3.0",
-		"symbiote/silverstripe-multisites": "~2.0",
+		"symbiote/silverstripe-multisites": "~4.0",
 		"symbiote/silverstripe-sitemap": "~1.0",
 		"silverstripe/listingpage": "~1.0",
 		"symbiote/silverstripe-queuedjobs": "~2.4",


### PR DESCRIPTION
Just double checking there's not some particular reason this was left on a version that has the silverstripe-australia vendor namespace?